### PR TITLE
net-test: packetdrill: Remove TUN_F_UFO from offload flags

### DIFF
--- a/gtests/net/packetdrill/netdev.c
+++ b/gtests/net/packetdrill/netdev.c
@@ -202,7 +202,7 @@ static void set_device_offload_flags(struct local_netdev *netdev)
 {
 #ifdef linux
 	const u32 offload =
-	    TUN_F_CSUM | TUN_F_TSO4 | TUN_F_TSO6 | TUN_F_TSO_ECN | TUN_F_UFO;
+	    TUN_F_CSUM | TUN_F_TSO4 | TUN_F_TSO6 | TUN_F_TSO_ECN;
 	if (ioctl(netdev->tun_fd, TUNSETOFFLOAD, offload) != 0)
 		die_perror("TUNSETOFFLOAD");
 #endif

--- a/gtests/net/packetdrill/tun.h
+++ b/gtests/net/packetdrill/tun.h
@@ -90,7 +90,6 @@
 #define TUN_F_TSO4      0x02    /* I can handle TSO for IPv4 packets */
 #define TUN_F_TSO6      0x04    /* I can handle TSO for IPv6 packets */
 #define TUN_F_TSO_ECN   0x08    /* I can handle TSO with ECN bits. */
-#define TUN_F_UFO       0x10    /* I can handle UFO packets */
 
 /* Protocol info prepended to the packets (when IFF_NO_PI is not set) */
 #define TUN_PKT_STRIP   0x0001


### PR DESCRIPTION
Commit d591a1f3aad92ade4642e4173f4c368006c27f0f in the Linux kernel removed
handling of the TUN_F_UFO flag in the set_offload() function for tun devices (in
net/tun.c).

Because of this, when TUN_F_UFO (0x10) is set in the argument for an
ioctl(..., TUNSETOFFLOAD, ...) call on a tun device, an error will be indicated,
with errno set to EINVAL.

The output of packdrill in this case looks like this:

    TUNSETOFFLOAD: Invalid argument

This change removes the TUN_F_UFO flag from the argument in order to avoid this
problem.