### PR TITLE
update _tcp_info data structure according to linux 4.14 kernel

### DIFF
--- a/gtests/net/packetdrill/code.c
+++ b/gtests/net/packetdrill/code.c
@@ -141,6 +141,8 @@ static void write_tcp_info(struct code_state *code,
 	emit_var(code, "tcpi_options",		info->tcpi_options);
 	emit_var(code, "tcpi_snd_wscale",	info->tcpi_snd_wscale);
 	emit_var(code, "tcpi_rcv_wscale",	info->tcpi_rcv_wscale);
+	emit_var(code, "tcpi_delivery_rate_app_limited",
+						info->tcpi_delivery_rate_app_limited);
 	emit_var(code, "tcpi_rto",		info->tcpi_rto);
 	emit_var(code, "tcpi_ato",		info->tcpi_ato);
 	emit_var(code, "tcpi_snd_mss",		info->tcpi_snd_mss);
@@ -162,10 +164,29 @@ static void write_tcp_info(struct code_state *code,
 	emit_var(code, "tcpi_snd_cwnd",		info->tcpi_snd_cwnd);
 	emit_var(code, "tcpi_advmss",		info->tcpi_advmss);
 	emit_var(code, "tcpi_reordering",	info->tcpi_reordering);
-	emit_var(code, "tcpi_total_retrans",	info->tcpi_total_retrans);
 
 	emit_var(code, "tcpi_rcv_rtt",		info->tcpi_rcv_rtt);
 	emit_var(code, "tcpi_rcv_space",	info->tcpi_rcv_space);
+
+	emit_var(code, "tcpi_total_retrans",	info->tcpi_total_retrans);
+
+	emit_var(code, "tcpi_pacing_rate",	info->tcpi_pacing_rate);
+	emit_var(code, "tcpi_max_pacing_rate",	info->tcpi_max_pacing_rate);
+	emit_var(code, "tcpi_bytes_acked",	info->tcpi_bytes_acked);
+	emit_var(code, "tcpi_bytes_received",	info->tcpi_bytes_received);
+	emit_var(code, "tcpi_segs_out",		info->tcpi_segs_out);
+	emit_var(code, "tcpi_segs_in",		info->tcpi_segs_in);
+
+	emit_var(code, "tcpi_notsent_bytes",	info->tcpi_notsent_bytes);
+	emit_var(code, "tcpi_min_rtt",		info->tcpi_min_rtt);
+	emit_var(code, "tcpi_data_segs_in",	info->tcpi_data_segs_in);
+	emit_var(code, "tcpi_data_segs_out",	info->tcpi_data_segs_out);
+
+	emit_var(code, "tcpi_delivery_rate",	info->tcpi_delivery_rate);
+
+	emit_var(code, "tcpi_busy_time",	info->tcpi_busy_time);
+	emit_var(code, "tcpi_rwnd_limited",	info->tcpi_rwnd_limited);
+	emit_var(code, "tcpi_sndbuf_limited",	info->tcpi_sndbuf_limited);
 
 	emit_var_end(code);
 }

--- a/gtests/net/packetdrill/tcp.h
+++ b/gtests/net/packetdrill/tcp.h
@@ -133,6 +133,7 @@ struct _tcp_info {
 	__u8	tcpi_backoff;
 	__u8	tcpi_options;
 	__u8	tcpi_snd_wscale:4, tcpi_rcv_wscale:4;
+	__u8	tcpi_delivery_rate_app_limited:1;
 
 	__u32	tcpi_rto;
 	__u32	tcpi_ato;
@@ -165,6 +166,24 @@ struct _tcp_info {
 	__u32	tcpi_rcv_space;
 
 	__u32	tcpi_total_retrans;
+
+	__u64	tcpi_pacing_rate;
+	__u64	tcpi_max_pacing_rate;
+	__u64	tcpi_bytes_acked;    /* RFC4898 tcpEStatsAppHCThruOctetsAcked */
+	__u64	tcpi_bytes_received; /* RFC4898 tcpEStatsAppHCThruOctetsReceived */
+	__u32	tcpi_segs_out;	     /* RFC4898 tcpEStatsPerfSegsOut */
+	__u32	tcpi_segs_in;	     /* RFC4898 tcpEStatsPerfSegsIn */
+
+	__u32	tcpi_notsent_bytes;
+	__u32	tcpi_min_rtt;
+	__u32	tcpi_data_segs_in;	/* RFC4898 tcpEStatsDataSegsIn */
+	__u32	tcpi_data_segs_out;	/* RFC4898 tcpEStatsDataSegsOut */
+
+	__u64   tcpi_delivery_rate;
+
+	__u64	tcpi_busy_time;      /* Time (usec) busy sending data */
+	__u64	tcpi_rwnd_limited;   /* Time (usec) limited by receive window */
+	__u64	tcpi_sndbuf_limited; /* Time (usec) limited by send buffer */
 };
 
 #endif  /* linux */


### PR DESCRIPTION
There are new fields added into tcp_info data structure in
comparison of linux 4.14 kernel. This patch updates packetdrill's copy
of that structure (_tcp_info), as well as the function, write_tcp_info().