### PR TITLE
packetdrill/Makefile.common: Disable address-of-packed-member

### DIFF
--- a/gtests/net/packetdrill/Makefile.common
+++ b/gtests/net/packetdrill/Makefile.common
@@ -1,6 +1,18 @@
+try-run = $(shell set -e;		\
+	TMP="$$.tmp";			\
+	if ($(1)) >/dev/null 2>&1;	\
+	then echo "$(2)";		\
+	else echo "$(3)";		\
+	fi;				\
+	rm -f "$$TMP")
+
+disable-option = $(call try-run,\
+	$(CC) -Werror -Waddress-of-packed-member -c -x c /dev/null -o "$$TMP",\
+	-Wno-address-of-packed-member)
+
 all: binaries
 
-CFLAGS = -g -Wall -Werror
+CFLAGS = -g -Wall -Werror $(disable-option)
 
 parser.o: parser.y
 	bison --output=parser.c --defines=parser.h --report=state parser.y


### PR DESCRIPTION
gcc-9 introduces and enables address-of-packed-member by
default so that gcc-9 with -Werror marks taking address
of packed member of 'struct tcp_option' as a error.

Disable address-of-packed-member when the option is supported.

Note:
1) This method is ported from upstream kernel.
2) Don't use -Wno-address-of-packed-member driectly because
   old compilers didn't accept unrecognized option in some
   cases.  See the URL for explanation:
   https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=8417da6f2128008c431c7d130af6cd3d9079922e

Signed-off-by: Xiao Yang <xiaox.yang@intel.com>