### PR TITLE
run_system_call.c: rename gettid() to sys_gettid()

### DIFF
--- a/gtests/net/packetdrill/run_system_call.c
+++ b/gtests/net/packetdrill/run_system_call.c
@@ -63,7 +63,7 @@ static int syscall_icmp_sendto(struct state *state,
 			       struct expression_list *args, char **error);
 
 /* Provide a wrapper for the Linux gettid() system call (glibc does not). */
-static pid_t gettid(void)
+static pid_t sys_gettid(void)
 {
 #ifdef linux
 	return syscall(__NR_gettid);
@@ -3441,7 +3441,7 @@ static void *system_call_thread(void *arg)
 	DEBUGP("syscall thread: starting and locking\n");
 	run_lock(state);
 
-	state->syscalls->thread_id = gettid();
+	state->syscalls->thread_id = sys_gettid();
 	if (state->syscalls->thread_id < 0)
 		die_perror("gettid");
 


### PR DESCRIPTION
the newer glibc already implemented system call gettid(),
rename it to prevent compiling errors

root@clr-book/tmp/build-packetdrill/packetdrill/gtests/net/packetdrill # make
gcc -g -Wall -Werror   -c -o code.o code.c
gcc -g -Wall -Werror   -c -o symbols_linux.o symbols_linux.c
gcc -g -Wall -Werror   -c -o run_system_call.o run_system_call.c
run_system_call.c:66:14: error: static declaration of ‘gettid’ follows non-static declaration
   66 | static pid_t gettid(void)
      |              ^~~~~~
In file included from /usr/include/unistd.h:1170,
                 from run_system_call.c:46:
/usr/include/bits/unistd_ext.h:34:16: note: previous declaration of ‘gettid’ was here
   34 | extern __pid_t gettid (void) __THROW;

Signed-off-by: Li Zhijian <zhijianx.li@intel.com>