### PR TITLE
packetdrill: suppress warning address-of-packed-member on tcp timestamp

### DIFF
--- a/gtests/net/packetdrill/run_packet.c
+++ b/gtests/net/packetdrill/run_packet.c
@@ -26,6 +26,7 @@
 
 #include <arpa/inet.h>
 #include <netinet/in.h>
+#include <stddef.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/socket.h>
@@ -404,10 +405,13 @@ static int find_tcp_timestamp(struct packet *packet, char **error)
 	for (option = tcp_options_begin(packet, &iter); option != NULL;
 	     option = tcp_options_next(&iter, error))
 		if (option->kind == TCPOPT_TIMESTAMP) {
-			packet->tcp_ts_val =
-				(void *)&(option->data.time_stamp.val);
-			packet->tcp_ts_ecr =
-				(void *)&(option->data.time_stamp.ecr);
+			const size_t val_off = offsetof(struct tcp_option,
+							data.time_stamp.val);
+			const size_t ecr_off = offsetof(struct tcp_option,
+							data.time_stamp.ecr);
+
+			packet->tcp_ts_val = (void *)((char *)option + val_off);
+			packet->tcp_ts_ecr = (void *)((char *)option + ecr_off);
 		}
 	return *error ? STATUS_ERR : STATUS_OK;
 }


### PR DESCRIPTION
Packetdrill needs to read and write possibly unaligned fields inside
tpc headers. The accesses are safe, using unaligned_be32 helpers.

Recent versions of GCC start warning about the pointers to these
fields, which causes build failure due to -Werror.
Suppress the warning for this specific safe case.

"
run_packet.c: In function ‘find_tcp_timestamp’:
run_packet.c:408:13: error: taking address of packed member of ‘struct tcp_option’ may result in an unaligned pointer value []
  408 |     (void *)&(option->data.time_stamp.val);
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
run_packet.c:410:13: error: taking address of packed member of ‘struct tcp_option’ may result in an unaligned pointer value []
  410 |     (void *)&(option->data.time_stamp.ecr);
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
"

Signed-off-by: Willem de Bruijn <willemb@google.com>