### PR TITLE
packetdrill: extend run_all.py to alllow testing a single packetdrill…

### DIFF
--- a/gtests/net/packetdrill/run_all.py
+++ b/gtests/net/packetdrill/run_all.py
@@ -26,6 +26,8 @@ class TestSet(object):
 
   def FindTests(self, path='.'):
     """Return all *.pkt files in a given directory and its subdirectories."""
+    if os.path.isfile(path):
+      return [path]
     tests = []
     for dirpath, _, filenames in os.walk(path):
       for filename in fnmatch.filter(filenames, '*.pkt'):
@@ -81,7 +83,7 @@ class TestSet(object):
          '-D CMSG_TYPE_RECVERR=IPV6_RECVERR')
     )
 
-  def StartDir(self, tests):
+  def StartTests(self, tests):
     """Run every test in tests in all three variants (v4, v6, v4-mapped-v6)."""
     procs = []
     for test in tests:
@@ -138,12 +140,12 @@ class TestSet(object):
       if self.args['verbose']:
         print 'KILL [%s (%s)]' % (path, variant)
 
-  def RunDir(self, path):
-    """Find all packetdrill scripts in a directory and run them."""
+  def RunTests(self, path):
+    """Find all packetdrill scripts in a path and run them."""
     tests = self.FindTests(path)
 
     time_start = time.time()
-    procs = self.StartDir(tests)
+    procs = self.StartTests(tests)
     self.PollTestSet(procs, time_start)
 
     print(
@@ -166,7 +168,7 @@ class TestSetThread(threading.Thread):
 
   def run(self):
     """Call the main method in this thread."""
-    self.testset.RunDir(self.path)
+    self.testset.RunTests(self.path)
 
 
 class ParallelTestSet(object):


### PR DESCRIPTION
… script

Previously, run_all.py only supported an input path that was a
directory. This commit extends the logic to support a path that is a
single packetdrill script file.

Before this commit:

./packetdrill/run_all.py -v tcp/fastopen/client/poll-ts.pkt
Ran    0 tests:    0 passing,    0 failing,    0 timed out (0.00 sec): tcp/fastopen/client/poll-ts.pkt

After this commit:

./packetdrill/run_all.py -v tcp/fastopen/client/poll-ts.pkt
OK   [/home/ncardwell/packetdrill/gtests/net/tcp/fastopen/client/poll-ts.pkt (ipv4)]
OK   [/home/ncardwell/packetdrill/gtests/net/tcp/fastopen/client/poll-ts.pkt (ipv6)]
OK   [/home/ncardwell/packetdrill/gtests/net/tcp/fastopen/client/poll-ts.pkt (ipv4-mapped-v6)]
Ran    3 tests:    3 passing,    0 failing,    0 timed out (2.01 sec): tcp/fastopen/client/poll-ts.pkt

Signed-off-by: Neal Cardwell <ncardwell@google.com>