### PR TITLE
fix 'error: ‘SIOCGSTAMP’ undeclared'

### DIFF
--- a/gtests/net/packetdrill/packet_socket_linux.c
+++ b/gtests/net/packetdrill/packet_socket_linux.c
@@ -36,6 +36,7 @@
 
 #include <netpacket/packet.h>
 #include <linux/filter.h>
+#include <linux/sockios.h>
 
 #include "assert.h"
 #include "ethernet.h"


### PR DESCRIPTION
```
[sergey@chang packetdrill]$ ./configure 
[sergey@chang packetdrill]$ make
cc -g -Wall -Werror   -c -o packetdrill.o packetdrill.c
cc -g -Wall -Werror   -c -o checksum.o checksum.c
cc -g -Wall -Werror   -c -o code.o code.c
cc -g -Wall -Werror   -c -o config.o config.c
cc -g -Wall -Werror   -c -o hash.o hash.c
cc -g -Wall -Werror   -c -o hash_map.o hash_map.c
cc -g -Wall -Werror   -c -o ip_address.o ip_address.c
cc -g -Wall -Werror   -c -o ip_prefix.o ip_prefix.c
cc -g -Wall -Werror   -c -o netdev.o netdev.c
cc -g -Wall -Werror   -c -o net_utils.o net_utils.c
cc -g -Wall -Werror   -c -o packet.o packet.c
cc -g -Wall -Werror   -c -o packet_socket_linux.o packet_socket_linux.c
packet_socket_linux.c: In function ‘packet_socket_setup’:
packet_socket_linux.c:100:26: error: ‘SIOCGSTAMP’ undeclared (first use in this function)
  ioctl(psock->packet_fd, SIOCGSTAMP, &tv);
                          ^
packet_socket_linux.c:100:26: note: each undeclared identifier is reported only once for each function it appears in
packet_socket_linux.c: In function ‘packet_socket_receive’:
packet_socket_linux.c:270:30: error: ‘SIOCGSTAMP’ undeclared (first use in this function)
  if (ioctl(psock->packet_fd, SIOCGSTAMP, &tv) < 0)
                              ^
make: *** [packet_socket_linux.o] Error 1
```

--- 

Signed-off-by: Sergey Chang sergeychang@gmail.com