### PR TITLE
support AccECN signaling in packetdrill

### DIFF
--- a/gtests/net/packetdrill/packet.h
+++ b/gtests/net/packetdrill/packet.h
@@ -104,6 +104,7 @@ struct packet {
 	u32 flags;		/* various meta-flags */
 #define FLAG_WIN_NOCHECK	0x1  /* don't check TCP receive window */
 #define FLAG_OPTIONS_NOCHECK	0x2  /* don't check TCP options */
+#define FLAG_PARSE_ACE		0x400 /* when set, output parsed AccECN ACE field */
 
 	enum tos_chk_t tos_chk;	/* how to treat the TOS byte of a packet */
 

--- a/gtests/net/packetdrill/packet_to_string.c
+++ b/gtests/net/packetdrill/packet_to_string.c
@@ -201,13 +201,6 @@ static int tcp_packet_to_string(FILE *s, struct packet *packet,
 		}
 	}
 
-	if (packet->tcp->ece)
-		fputc('E', s);   /* ECN *E*cho sent (ECN) */
-	if (packet->tcp->cwr)
-		fputc('W', s);   /* Congestion *W*indow reduced (ECN) */
-	if (packet->tcp->ae)
-		fputc('A', s);   /* AccECN bit */
-
 	fprintf(s, " %u:%u(%u) ",
 		ntohl(packet->tcp->seq),
 		ntohl(packet->tcp->seq) + packet_payload_len(packet),

--- a/gtests/net/packetdrill/packet_to_string.c
+++ b/gtests/net/packetdrill/packet_to_string.c
@@ -186,11 +186,13 @@ static int tcp_packet_to_string(FILE *s, struct packet *packet,
 			fputc('A', s);   /* AccECN bit */
 
 		/* Check for AccECN handshake */
-		if (packet->tcp->syn && !packet->tcp->ack &&
-		    packet->tcp->ae && packet->tcp->cwr && packet->tcp->cwr)
-			parse_tcp_ace_field = true;
-		else if (packet->tcp->syn && packet->tcp->ack &&
-			parse_tcp_ace_field) {
+		if (packet->tcp->syn && !packet->tcp->ack) {
+			if(packet->tcp->ae && packet->tcp->cwr && packet->tcp->ece)
+				parse_tcp_ace_field = true;
+			else
+				parse_tcp_ace_field = false;
+		} else
+		if (packet->tcp->syn && packet->tcp->ack && parse_tcp_ace_field) {
 			if ((!packet->tcp->ae &&  packet->tcp->cwr && !packet->tcp->ece) ||
 			    (!packet->tcp->ae &&  packet->tcp->cwr &&  packet->tcp->ece) ||
 			    ( packet->tcp->ae && !packet->tcp->cwr && !packet->tcp->ece) ||

--- a/gtests/net/packetdrill/packet_to_string.c
+++ b/gtests/net/packetdrill/packet_to_string.c
@@ -168,7 +168,7 @@ static int tcp_packet_to_string(FILE *s, struct packet *packet,
 		fputc('.', s);
 	if (packet->tcp->urg)
 		fputc('U', s);
-	if (!packet->tcp->syn && parse_tcp_ace_field) {
+	if (packet->flags & FLAG_PARSE_ACE) {
 		int ace = 0;
 		if (packet->tcp->ece)
 			ace |= 1;
@@ -184,23 +184,6 @@ static int tcp_packet_to_string(FILE *s, struct packet *packet,
 			fputc('W', s);   /* Congestion *W*indow reduced (ECN) */
 		if (packet->tcp->ae)
 			fputc('A', s);   /* AccECN bit */
-
-		/* Check for AccECN handshake */
-		if (packet->tcp->syn && !packet->tcp->ack) {
-			if(packet->tcp->ae && packet->tcp->cwr && packet->tcp->ece)
-				parse_tcp_ace_field = true;
-			else
-				parse_tcp_ace_field = false;
-		} else
-		if (packet->tcp->syn && packet->tcp->ack && parse_tcp_ace_field) {
-			if ((!packet->tcp->ae &&  packet->tcp->cwr && !packet->tcp->ece) ||
-			    (!packet->tcp->ae &&  packet->tcp->cwr &&  packet->tcp->ece) ||
-			    ( packet->tcp->ae && !packet->tcp->cwr && !packet->tcp->ece) ||
-			    ( packet->tcp->ae &&  packet->tcp->cwr && !packet->tcp->ece))
-				parse_tcp_ace_field = true;
-			else
-				parse_tcp_ace_field = false;
-		}
 	}
 
 	fprintf(s, " %u:%u(%u) ",

--- a/gtests/net/packetdrill/packet_to_string.c
+++ b/gtests/net/packetdrill/packet_to_string.c
@@ -172,6 +172,8 @@ static int tcp_packet_to_string(FILE *s, struct packet *packet,
 		fputc('E', s);   /* ECN *E*cho sent (ECN) */
 	if (packet->tcp->cwr)
 		fputc('W', s);   /* Congestion *W*indow reduced (ECN) */
+	if (packet->tcp->ae)
+		fputc('A', s);   /* AccECN bit */
 
 	fprintf(s, " %u:%u(%u) ",
 		ntohl(packet->tcp->seq),

--- a/gtests/net/packetdrill/packet_to_string.h
+++ b/gtests/net/packetdrill/packet_to_string.h
@@ -33,7 +33,7 @@ enum dump_format_t {
 	DUMP_VERBOSE,		/* add hex dump */
 };
 
-static bool parse_tcp_ace_field = false;
+bool parse_tcp_ace_field;
 
 /* Returns in *ascii_string a human-readable representation of the
  * packet 'packet'. Returns STATUS_OK on success; on failure returns

--- a/gtests/net/packetdrill/packet_to_string.h
+++ b/gtests/net/packetdrill/packet_to_string.h
@@ -33,6 +33,8 @@ enum dump_format_t {
 	DUMP_VERBOSE,		/* add hex dump */
 };
 
+static bool parse_tcp_ace_field = false;
+
 /* Returns in *ascii_string a human-readable representation of the
  * packet 'packet'. Returns STATUS_OK on success; on failure returns
  * STATUS_ERR and sets error message.

--- a/gtests/net/packetdrill/packet_to_string.h
+++ b/gtests/net/packetdrill/packet_to_string.h
@@ -33,8 +33,6 @@ enum dump_format_t {
 	DUMP_VERBOSE,		/* add hex dump */
 };
 
-bool parse_tcp_ace_field;
-
 /* Returns in *ascii_string a human-readable representation of the
  * packet 'packet'. Returns STATUS_OK on success; on failure returns
  * STATUS_ERR and sets error message.

--- a/gtests/net/packetdrill/parser.y
+++ b/gtests/net/packetdrill/parser.y
@@ -1104,6 +1104,8 @@ ip_ecn
 
 flags
 : WORD         { $$ = $1; }
+| INTEGER      { $$ = strdup(yytext); }
+| INTEGER '.'  { asprintf(&($$), "%lld.", $1); }
 | '.'          { $$ = strdup("."); }
 | WORD '.'     { asprintf(&($$), "%s.", $1); free($1); }
 | '-'          { $$ = strdup(""); }  /* no TCP flags set in segment */

--- a/gtests/net/packetdrill/run_packet.c
+++ b/gtests/net/packetdrill/run_packet.c
@@ -891,15 +891,24 @@ static int verify_tcp(
 	    check_field("tcp_urg",
 			script_tcp->urg,
 			actual_tcp->urg, error) ||
-	    check_field("tcp_ece",
+	    (parse_tcp_ace_field &&
+		check_field("tcp_ace",
+			(script_tcp->ae  ? 4 : 0) |
+			(script_tcp->cwr ? 2 : 0) |
+			(script_tcp->ece ? 1 : 0),
+			(actual_tcp->ae  ? 4 : 0) |
+			(actual_tcp->cwr ? 2 : 0) |
+			(actual_tcp->ece ? 1 : 0), error)) ||
+	    (!parse_tcp_ace_field &&
+		(check_field("tcp_ece",
 			script_tcp->ece,
 			actual_tcp->ece, error) ||
-	    (strict && check_field("tcp_cwr",
+		(strict && check_field("tcp_cwr",
 			script_tcp->cwr,
 			actual_tcp->cwr, error)) ||
-	    check_field("tcp_ae",
+		check_field("tcp_ae",
 			script_tcp->ae,
-			actual_tcp->ae,  error) ||
+			actual_tcp->ae,  error))) ||
 	    check_field("tcp_reserved_bits",
 			script_tcp->res1,
 			actual_tcp->res1, error) ||

--- a/gtests/net/packetdrill/run_packet.c
+++ b/gtests/net/packetdrill/run_packet.c
@@ -891,7 +891,7 @@ static int verify_tcp(
 	    check_field("tcp_urg",
 			script_tcp->urg,
 			actual_tcp->urg, error) ||
-	    (parse_tcp_ace_field &&
+	    ((script_packet->flags & FLAG_PARSE_ACE) &&
 		check_field("tcp_ace",
 			(script_tcp->ae  ? 4 : 0) |
 			(script_tcp->cwr ? 2 : 0) |
@@ -899,7 +899,7 @@ static int verify_tcp(
 			(actual_tcp->ae  ? 4 : 0) |
 			(actual_tcp->cwr ? 2 : 0) |
 			(actual_tcp->ece ? 1 : 0), error)) ||
-	    (!parse_tcp_ace_field &&
+	    (!(script_packet->flags & FLAG_PARSE_ACE) &&
 		(check_field("tcp_ece",
 			script_tcp->ece,
 			actual_tcp->ece, error) ||

--- a/gtests/net/packetdrill/run_packet.c
+++ b/gtests/net/packetdrill/run_packet.c
@@ -897,6 +897,9 @@ static int verify_tcp(
 	    (strict && check_field("tcp_cwr",
 			script_tcp->cwr,
 			actual_tcp->cwr, error)) ||
+	    check_field("tcp_ae",
+			script_tcp->ae,
+			actual_tcp->ae,  error) ||
 	    check_field("tcp_reserved_bits",
 			script_tcp->res1,
 			actual_tcp->res1, error) ||

--- a/gtests/net/packetdrill/tcp.h
+++ b/gtests/net/packetdrill/tcp.h
@@ -113,7 +113,8 @@ struct tcp {
 	__be32	seq;
 	__be32	ack_seq;
 #  if __BYTE_ORDER == __LITTLE_ENDIAN
-	__u16	res1:4,
+	__u16	ae:1,
+		res1:3,
 		doff:4,
 		fin:1,
 		syn:1,
@@ -125,7 +126,8 @@ struct tcp {
 		cwr:1;
 #  elif __BYTE_ORDER == __BIG_ENDIAN
 	__u16	doff:4,
-		res1:4,
+		res1:3,
+		ae:1,
 		cwr:1,
 		ece:1,
 		urg:1,

--- a/gtests/net/packetdrill/tcp_packet.c
+++ b/gtests/net/packetdrill/tcp_packet.c
@@ -199,9 +199,9 @@ struct packet *new_tcp_packet(int address_family,
 
 	if ((ace = tcp_flag_ace_count(flags)) != 0) {
 		/* after validity check, ACE value doesn't coexist with ECN flags */
-		packet->tcp->ece = (ace & 1);
-		packet->tcp->cwr = (ace & 2);
-		packet->tcp->ae  = (ace & 4);
+		packet->tcp->ece = ((ace & 1) == 1);
+		packet->tcp->cwr = ((ace & 2) == 2);
+		packet->tcp->ae  = ((ace & 4) == 4);
 	} else {
 		packet->tcp->ece = is_tcp_flag_set('E', flags);
 		packet->tcp->cwr = is_tcp_flag_set('W', flags);

--- a/gtests/net/packetdrill/tcp_packet.c
+++ b/gtests/net/packetdrill/tcp_packet.c
@@ -204,6 +204,7 @@ struct packet *new_tcp_packet(int address_family,
 		 * Need to force a boolean check for the 
 		 * 1 bit fields to get correctly set
 		 */
+		packet->flags |= FLAG_PARSE_ACE;
 		packet->tcp->ece = ((ace & 1) != 0);
 		packet->tcp->cwr = ((ace & 2) != 0);
 		packet->tcp->ae  = ((ace & 4) != 0);

--- a/gtests/net/packetdrill/tcp_packet.c
+++ b/gtests/net/packetdrill/tcp_packet.c
@@ -198,10 +198,15 @@ struct packet *new_tcp_packet(int address_family,
 	packet->tcp->urg = is_tcp_flag_set('U', flags);
 
 	if ((ace = tcp_flag_ace_count(flags)) != 0) {
-		/* after validity check, ACE value doesn't coexist with ECN flags */
-		packet->tcp->ece = ((ace & 1) == 1);
-		packet->tcp->cwr = ((ace & 2) == 2);
-		packet->tcp->ae  = ((ace & 4) == 4);
+		/* 
+		 * after validity check, ACE value doesn't 
+		 * coexist with ECN flags 
+		 * Need to force a boolean check for the 
+		 * 1 bit fields to get correctly set
+		 */
+		packet->tcp->ece = ((ace & 1) != 0);
+		packet->tcp->cwr = ((ace & 2) != 0);
+		packet->tcp->ae  = ((ace & 4) != 0);
 	} else {
 		packet->tcp->ece = is_tcp_flag_set('E', flags);
 		packet->tcp->cwr = is_tcp_flag_set('W', flags);

--- a/gtests/net/packetdrill/tcp_packet.c
+++ b/gtests/net/packetdrill/tcp_packet.c
@@ -55,7 +55,7 @@ static bool is_tcp_flags_spec_valid(const char *flags, char **error)
 		}
 		if (strchr(ecn_tcp_flags, *s)) {
 			has_ecn_flag = true;
-			if (has_ace_flag)  {
+			if (has_ace_flag) {
 				asprintf(error, "Conflicting TCP flag: '%c'", *s);
 				return false;
 			}

--- a/gtests/net/packetdrill/tcp_packet.c
+++ b/gtests/net/packetdrill/tcp_packet.c
@@ -89,7 +89,7 @@ static inline int tcp_flag_ace_count( const char *flags)
 
 	for (s = flags; *s != '\0'; ++s) {
 		if (strchr(ace_tcp_flags, *s)) {
-			return ((int)s - (int)'0');
+			return ((int)*s - (int)'0');
 		}
 	}
 	return 0;


### PR DESCRIPTION
As discussed, this is the manually prepared patch to include AccECN support on HEAD packetdrill.

It does not compile on my bsd box, please verify that existing ECN-using scripts continue to run.