### PR TITLE
packetdrill: skip defining gettid() on Linux with glibc 2.30+

### DIFF
--- a/gtests/net/packetdrill/run_system_call.c
+++ b/gtests/net/packetdrill/run_system_call.c
@@ -62,17 +62,24 @@ static int syscall_icmp_sendto(struct state *state,
 			       struct syscall_spec *syscall,
 			       struct expression_list *args, char **error);
 
-/* Provide a wrapper for the Linux gettid() system call (glibc does not). */
+#if defined(linux)
+/* Provide a wrapper for the Linux gettid() system call
+ * (glibc only provides it in version 2.30 or higher).
+ */
+#if (__GLIBC__ < 2) || ((__GLIBC__ == 2) && (__GLIBC_MINOR__ < 30))
 static pid_t gettid(void)
 {
-#ifdef linux
 	return syscall(__NR_gettid);
-#endif
+}
+#endif  /* old glibc versions */
+#endif  /* defined(linux) */
 #if defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__)
+static pid_t gettid(void)
+{
 	/* TODO(ncardwell): Implement me. XXX */
 	return 0;
-#endif /* defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__)*/
 }
+#endif /* defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__)*/
 
 /* Read a whole file into the given buffer of the given length. */
 static void read_whole_file(const char *path, char *buffer, int max_bytes)


### PR DESCRIPTION
The glibc version 2.30 finally includes a gettid() function.

This means that recent Linux distributions like Ubuntu 19.10 encounter
compilation errors due to duplicate definitions:

run_system_call.c:66:14: error: static declaration of `gettid'
 follows non-static declaration
   66 | static pid_t gettid(void)
      |              ^~~~~~
In file included from /usr/include/unistd.h:1170,
                 from run_system_call.c:46:
/usr/include/x86_64-linux-gnu/bits/unistd_ext.h:34:16: note:
  previous declaration of `gettid' was here
   34 | extern __pid_t gettid (void) __THROW;
      |                ^~~~~~

This issue was brought up by Li Zhijian <zhijianx.li@intel.com>,
who also proposed a fix in:
  https://github.com/google/packetdrill/pull/19

The fix here is to constrain the definition of packetdrill's gettid()
so that it does not happen on Linux with glibc 2.30 and later.

This fix is inspired by the change:
  glib 2.30 or higher provides gettid().
  Michael Tuexen <tuexen@fh-muenster.de>
  https://github.com/nplab/packetdrill/commit/3094d75b9b9ad8fb7895726d3b40beb1d961df64

Signed-off-by: Neal Cardwell <ncardwell@google.com>