### PR TITLE
packetdrill: fix compilation/runtime error for linux 3.x

### DIFF
--- a/gtests/net/packetdrill/code.c
+++ b/gtests/net/packetdrill/code.c
@@ -141,8 +141,6 @@ static void write_tcp_info(struct code_state *code,
 				   const struct _tcp_info *info,
 				   int len)
 {
-	assert(len >= sizeof(struct _tcp_info));
-
 	write_symbols(code);
 
 	/* Emit the recorded values of tcpi_foo values. */
@@ -204,6 +202,7 @@ static void write_tcp_info(struct code_state *code,
 	emit_var_end(code);
 }
 
+#if HAVE_TCP_CC_INFO
 /* Write out a formatted representation of the given _tcp_bbr_info buffer. */
 static void write_tcp_bbr_cc_info(struct code_state *code,
 				  const union _tcp_cc_info *info,
@@ -270,7 +269,9 @@ static void write_tcp_cc_info(struct code_state *code,
 	write_tcp_vegas_cc_info(code, info, len);
 	emit_var_end(code);
 }
+#endif  /* HAVE_TCP_CC_INFO */
 
+#if HAVE_SO_MEMINFO
 /* Write out a formatted representation of the given mem_info buffer. */
 static void write_so_meminfo(struct code_state *code,
 			     const u32 *mem_info,
@@ -290,6 +291,7 @@ static void write_so_meminfo(struct code_state *code,
 
 	emit_var_end(code);
 }
+#endif	/* HAVE_SO_MEMINFO */
 #endif  /* linux */
 
 #if defined(__FreeBSD__)
@@ -299,8 +301,6 @@ static void write_tcp_info(struct code_state *code,
 				   const struct _tcp_info *info,
 				   int len)
 {
-	assert(len >= sizeof(struct _tcp_info));
-
 	write_symbols(code);
 
 	/* Emit the recorded values of tcpi_foo values. */
@@ -735,7 +735,6 @@ void run_code_event(struct state *state, struct event *event,
 
 	void *data = NULL;
 	void *data_ext = NULL;
-	void *data_meminfo = NULL;
 	int  data_len = 0;
 #if HAVE_TCP_INFO
 	code->data_type = DATA_TCP_INFO;
@@ -761,6 +760,7 @@ void run_code_event(struct state *state, struct event *event,
 #endif  /* HAVE_TCP_CC_INFO */
 #if HAVE_SO_MEMINFO
 	code->data_type = DATA_SO_MEMINFO;
+	void *data_meminfo = NULL;
 	data_meminfo = get_data(state, event, fd, code->data_type, &data_len);
 	if (data_meminfo)
 		append_data(code, code->data_type, data_meminfo, data_len);


### PR DESCRIPTION
For linux 3.10, TCP_CC_INFO and SO_MEMINFO are not supported. When we
define HAVE_SO_MEMINFO / HAVE_TCP_CC_INFO as 0, functions like
write_tcp_bbr_cc_info and write_so_meminfo will not be accessed. So
wrap them with #ifdef and #endif.

Also, for lower linux version, tcp_info option value has less
fields(e.g. 120 bytes). So remove the size assert.

This commit is based on the following packetdrill upstream pull
request, with a slightly tweaked commit description:
  https://github.com/google/packetdrill/pull/13

Signed-off-by: Neal Cardwell <ncardwell@google.com>
Change-Id: I2f4f8cea7357356f2041eabed044b6f7616d4e91