### PR TITLE
Avoid Python error in case of timeout

### DIFF
--- a/gtests/net/packetdrill/run_all.py
+++ b/gtests/net/packetdrill/run_all.py
@@ -149,10 +149,12 @@ class TestSet(object):
           procs.remove(entry)
 
     self.num_timedout = len(procs)
-    for proc, path, variant, _, _ in procs:
+    for proc, path, variant, outfile, errfile in procs:
       proc.kill()
       if self.args['verbose']:
         print 'KILL [%s (%s)]' % (path, variant)
+        if self.args['log_on_error']:
+          self.Log(outfile, errfile)
 
   def RunTests(self, path):
     """Find all packetdrill scripts in a path and run them."""

--- a/gtests/net/packetdrill/run_all.py
+++ b/gtests/net/packetdrill/run_all.py
@@ -149,7 +149,7 @@ class TestSet(object):
           procs.remove(entry)
 
     self.num_timedout = len(procs)
-    for proc, path, variant in procs:
+    for proc, path, variant, _, _ in procs:
       proc.kill()
       if self.args['verbose']:
         print 'KILL [%s (%s)]' % (path, variant)


### PR DESCRIPTION
When a test is blocked and after a timeout, this Python error is produced:

      Exception in thread Thread-1:
      Traceback (most recent call last):
        File "/usr/lib/python3.6/threading.py", line 916, in _bootstrap_inner
          self.run()
        File "packetdrill/run_all.py", line 169, in run
          self.testset.RunDir(self.path)
        File "packetdrill/run_all.py", line 147, in RunDir
          self.PollTestSet(procs, time_start)
        File "packetdrill/run_all.py", line 136, in PollTestSet
          for proc, path, variant in procs:
      ValueError: too many values to unpack (expected 3)

That's simply because `procs` variable is an array of tuple containing 5 items. Two additional items are missing: `stdout` and `stderr`.

With the patch, we have a clearer error:

      KILL [/opt/packetdrill/gtests/net/mptcp/mp_join/mp_join_client.pkt (ipv4)]

A second commit prints more info in case of timeout if we are in verbose with `log_on_error` option.