### PR TITLE
packetdrill: fix compilation with GCC 10

### DIFF
--- a/gtests/net/packetdrill/tcp_options.h
+++ b/gtests/net/packetdrill/tcp_options.h
@@ -105,7 +105,7 @@ struct tcp_option {
 			u8 cookie[MAX_TCP_FAST_OPEN_EXP_COOKIE_BYTES];
 		} fast_open_exp;
 	} data;
-} __packed tcp_option;
+} __packed;
 
 /* Allocate a new options list. */
 extern struct tcp_options *tcp_options_new(void);


### PR DESCRIPTION
When compiling with GCC 10.2 under Fedora 32 compilation failed with a
bunch of messages like

/usr/bin/ld: tcp_packet.o:/tmp/packetdrill/gtests/net/packetdrill/tcp_options.h:108: multiple definition of `tcp_option'; packet_to_string.o:/tmp/packetdrill/gtests/net/packetdrill/tcp_options.h:108: first defined here
...
collect2: error: ld returned 1 exit status
make: *** [Makefile.common:37: packetdrill] Error 1

This is due to GCC 10 defaulting[0] to -fno-common and because
tcp_option is both defined and declared in tcp_option.h.

Simply removing the declaration part fixes the compilation.

[0]: https://gcc.gnu.org/gcc-10/porting_to.html

Signed-off-by: Andrew Clayton <andrew@digital-domain.net>