### PR TITLE
packetdrill: run_all: pass netmask to remote_ip arg

### DIFF
--- a/gtests/net/packetdrill/run_all.py
+++ b/gtests/net/packetdrill/run_all.py
@@ -64,7 +64,7 @@ class TestSet(object):
          '--local_ip=192.168.0.2 '
          '--gateway_ip=192.168.0.1 '
          '--netmask_ip=255.255.0.0 '
-         '--remote_ip=192.0.2.1 '
+         '--remote_ip=192.0.2.1/24 '
          '-D TFO_COOKIE=de4f234f0f433a55 '
          '-D CMSG_LEVEL_IP=SOL_IP '
          '-D CMSG_TYPE_RECVERR=IP_RECVERR')
@@ -77,7 +77,7 @@ class TestSet(object):
         ('--ip_version=ipv6 --mtu=1520 '
          '--local_ip=fd3d:fa7b:d17d::0 '
          '--gateway_ip=fd3d:fa7b:d17d:8888::0 '
-         '--remote_ip=2001:DB8::1 '
+         '--remote_ip=2001:DB8::1/32 '
          '-D TFO_COOKIE=6aa6ae70c288023b '
          '-D CMSG_LEVEL_IP=SOL_IPV6 '
          '-D CMSG_TYPE_RECVERR=IPV6_RECVERR')
@@ -91,7 +91,7 @@ class TestSet(object):
          '--local_ip=192.168.0.2 '
          '--gateway_ip=192.168.0.1 '
          '--netmask_ip=255.255.0.0 '
-         '--remote_ip=192.0.2.1 '
+         '--remote_ip=192.0.2.1/24 '
          '-D TFO_COOKIE=de4f234f0f433a55 '
          '-D CMSG_LEVEL_IP=SOL_IPV6 '
          '-D CMSG_TYPE_RECVERR=IPV6_RECVERR')

--- a/gtests/net/tcp/mtu_probe/basic-v4.pkt
+++ b/gtests/net/tcp/mtu_probe/basic-v4.pkt
@@ -14,7 +14,7 @@
  ../common/set_sysctls.py \
 	/proc/sys/net/ipv4/tcp_mtu_probing=2 \
 	/proc/sys/net/ipv4/tcp_base_mss=512
- ip route change 192.0.2.1 via 192.168.0.2 dev tun0 advmss 600 mtu lock 640 initcwnd 11
+ ip route add 192.0.2.1 via 192.168.0.2 dev tun0 advmss 600 mtu lock 640 initcwnd 11
  ethtool -K tun0 gso off tso off
 `
 

--- a/gtests/net/tcp/mtu_probe/basic-v6.pkt
+++ b/gtests/net/tcp/mtu_probe/basic-v6.pkt
@@ -16,7 +16,7 @@
  ../common/set_sysctls.py \
 	/proc/sys/net/ipv4/tcp_mtu_probing=2 \
 	/proc/sys/net/ipv4/tcp_base_mss=512
- ip -6 route change 2001:DB8::1 via fd3d:fa7b:d17d:8888::0 dev tun0 advmss 600 mtu lock 660 initcwnd 11
+ ip -6 route add 2001:DB8::1 via fd3d:fa7b:d17d:8888::0 dev tun0 advmss 600 mtu lock 660 initcwnd 11
  ethtool -K tun0 gso off tso off
 `
 


### PR DESCRIPTION
Makes no difference for upstream packetdrill, but this makes the
mptcp-fork 'join' tests work when run from the run_all script.

The mp_join tests add a secondary ip address.  Without the netmask the kernel can't find a route for the syn/ack packet and the tcp syn carrying the join request never gets a response.

The netmasks are the ones used in the two DEFAULT_V{4,6}_LIVE_REMOTE_IP_STRING defines.

The basic-v{4,6} test cases are adjusted to add a host-specific route rather than attempt to change a
(now no longer existing) entry.