### PR TITLE
gtests: net: packetdrill: run_all: make print python3+ compatible

### DIFF
--- a/gtests/net/packetdrill/run_all.py
+++ b/gtests/net/packetdrill/run_all.py
@@ -111,10 +111,10 @@ class TestSet(object):
 
   def Log(self, outfile, errfile):
     """Print a background process's stdout and stderr streams."""
-    print 'stdout: '
+    print('stdout: ')
     outfile.seek(0)
     sys.stdout.write(outfile.read())
-    print 'stderr: '
+    print('stderr: ')
     errfile.seek(0)
     sys.stderr.write(errfile.read())
 
@@ -128,13 +128,13 @@ class TestSet(object):
     if not process.returncode:
       self.num_pass += 1
       if self.args['verbose']:
-        print 'OK   [%s (%s)]' % (path, variant)
+        print('OK   [%s (%s)]' % (path, variant))
         if self.args['log_on_success']:
           self.Log(outfile, errfile)
     else:
       self.num_fail += 1
       if self.args['verbose']:
-        print 'FAIL [%s (%s)]' % (path, variant)
+        print('FAIL [%s (%s)]' % (path, variant))
         if self.args['log_on_error']:
           self.Log(outfile, errfile)
 
@@ -154,9 +154,9 @@ class TestSet(object):
         proc.kill()
       except:
         if self.args['verbose']:
-          print 'The test process has exited'
+          print('The test process has exited')
       if self.args['verbose']:
-        print 'KILL [%s (%s)]' % (path, variant)
+        print('KILL [%s (%s)]' % (path, variant))
         if self.args['log_on_error']:
           self.Log(outfile, errfile)
 


### PR DESCRIPTION
When python3 is used, this syntax error about 'missing parentheses'
shows up:

  File \". packetdrill run_all.py\", line 114
    print 'stdout: '
                   ^
SyntaxError: Missing parentheses in call to 'print'. Did you mean print'stdout: '?

Rework the patch by adding parentheses to the print(...) funciton.

Signed-off-by: Anders Roxell <anders.roxell@linaro.org>