### PR TITLE
net-test: packetdrill: run_all: add timeout flag

### DIFF
--- a/gtests/net/packetdrill/run_all.py
+++ b/gtests/net/packetdrill/run_all.py
@@ -19,7 +19,6 @@ class TestSet(object):
     self.args = args
     self.tools_path = os.path.abspath('./packetdrill')
     self.default_args = '--send_omit_free'
-    self.max_runtime = 180
     self.num_pass = 0
     self.num_fail = 0
     self.num_timedout = 0
@@ -142,7 +141,7 @@ class TestSet(object):
 
   def PollTestSet(self, procs, time_start):
     """Wait until a,l tests in procs have finished or until timeout."""
-    while time.time() - time_start < self.max_runtime and procs:
+    while time.time() - time_start < self.args['timeout_sec'] and procs:
       time.sleep(1)
       for entry in procs:
         if self.PollTest(entry):
@@ -239,6 +238,8 @@ def ParseArgs():
   args.add_argument('-p', '--parallelize_dirs', action='store_true')
   args.add_argument('-s', '--subdirs', action='store_true')
   args.add_argument('-S', '--serialized', action='store_true')
+  args.add_argument('-t', '--timeout_sec', nargs='?', const=180, type=int,
+                    default=180)
   args.add_argument('-v', '--verbose', action='store_true')
   return vars(args.parse_args())
 

--- a/gtests/net/packetdrill/run_all.py
+++ b/gtests/net/packetdrill/run_all.py
@@ -237,6 +237,8 @@ def ParseArgs():
                     help='requires verbose')
   args.add_argument('-L', '--log_on_success', action='store_true',
                     help='requires verbose')
+  args.add_argument('--no-traverse_subdirs', dest='traverse_subdirs',
+                    action='store_false')
   args.add_argument('-p', '--parallelize_dirs', action='store_true')
   args.add_argument('--no-traverse_subdirs', dest='traverse_subdirs',
                     action='store_false')

--- a/gtests/net/packetdrill/run_all.py
+++ b/gtests/net/packetdrill/run_all.py
@@ -31,6 +31,8 @@ class TestSet(object):
     for dirpath, _, filenames in os.walk(path):
       for filename in fnmatch.filter(filenames, '*.pkt'):
         tests.append(dirpath + '/' + filename)
+      if not self.args['traverse_subdirs']:
+        break
     return sorted(tests)
 
   def StartTest(self, path, variant, extra_args=None):
@@ -207,7 +209,7 @@ class ParallelTestSet(object):
     """Construct a test set for each subdirectory and run them in parallel."""
     errors = 0
 
-    if args['subdirs']:
+    if args['subdirs'] and args['traverse_subdirs']:
       paths = self.FindSubDirs(args['path'])
     else:
       paths = [args['path']]
@@ -236,6 +238,8 @@ def ParseArgs():
   args.add_argument('-L', '--log_on_success', action='store_true',
                     help='requires verbose')
   args.add_argument('-p', '--parallelize_dirs', action='store_true')
+  args.add_argument('--no-traverse_subdirs', dest='traverse_subdirs',
+                    action='store_false')
   args.add_argument('-s', '--subdirs', action='store_true')
   args.add_argument('-S', '--serialized', action='store_true')
   args.add_argument('-t', '--timeout_sec', nargs='?', const=180, type=int,


### PR DESCRIPTION
Enable passing a custom timeout value to run_all.py. If unspecified,
the default remains 180.

Tested: on kernel netdev-netnext/master HEAD at commit 5e437416ff669
(1) verify default timeout remains 180:
$ python ./packetdrill/run_all.py -S -v -L -l tcp/mss/mss-getsockopt-tcp_maxseg-server.pkt
OK   [/export/hda3/tmp/tannerlove/net/tcp/mss/mss-getsockopt-tcp_maxseg-server.pkt (ipv4)]
stdout:
stderr:
OK   [/export/hda3/tmp/tannerlove/net/tcp/mss/mss-getsockopt-tcp_maxseg-server.pkt (ipv6)]
stdout:
stderr:
OK   [/export/hda3/tmp/tannerlove/net/tcp/mss/mss-getsockopt-tcp_maxseg-server.pkt (ipv4-mapped-v6)]
stdout:
stderr:
Ran    3 tests:    3 passing,    0 failing,    0 timed out (3.83 sec): tcp/mss/mss-getsockopt-tcp_maxseg-server.pkt
(2) verify -t 0 results in timeout:
python ./packetdrill/run_all.py -S -v -L -l -t 0 tcp/mss/mss-getsockopt-tcp_maxseg-server.pkt
KILL [/export/hda3/tmp/tannerlove/net/tcp/mss/mss-getsockopt-tcp_maxseg-server.pkt (ipv4)]
stdout:
stderr:
KILL [/export/hda3/tmp/tannerlove/net/tcp/mss/mss-getsockopt-tcp_maxseg-server.pkt (ipv4-mapped-v6)]
stdout:
stderr:
KILL [/export/hda3/tmp/tannerlove/net/tcp/mss/mss-getsockopt-tcp_maxseg-server.pkt (ipv6)]
stdout:
stderr:
Ran    3 tests:    0 passing,    0 failing,    3 timed out (1.85 sec): tcp/mss/mss-getsockopt-tcp_maxseg-server.pkt

Signed-off-by: Tanner Love <tannerlove@google.com>