### PR TITLE
fix build issue with gcc 11

### DIFF
--- a/gtests/net/packetdrill/run_system_call.c
+++ b/gtests/net/packetdrill/run_system_call.c
@@ -3371,14 +3371,12 @@ static int await_idle_thread(struct state *state)
 
 static int yield(void)
 {
-#if defined(linux)
-	return pthread_yield();
-#elif defined(__FreeBSD__) || defined(__OpenBSD__)
+#if defined(__FreeBSD__) || defined(__OpenBSD__)
 	pthread_yield();
 	return 0;
-#elif defined(__NetBSD__)
+#elif defined(__NetBSD__) || defined(linux)
 	return sched_yield();
-#endif  /* defined(__NetBSD__) */
+#endif  /* defined(__NetBSD__) || defined(linux) */
 }
 
 /* Enqueue the system call for the syscall thread and wake up the thread. */


### PR DESCRIPTION
gcc 11 complains about use of deprecated pthread_yield(): replace it
with sched_yield().

Signed-off-by: Davide Caratti <dcaratti@redhat.com>