### PR TITLE
decode AccECN nicely with -v and on error

### DIFF
--- a/gtests/net/packetdrill/run_packet.c
+++ b/gtests/net/packetdrill/run_packet.c
@@ -1409,6 +1409,10 @@ out:
 	add_packet_dump(error, "script", script_packet, script_usecs,
 			DUMP_SHORT);
 	if (actual_packet != NULL) {
+		if (script_packet->flags & FLAG_PARSE_ACE) {
+			/* set numeric ACE count flag on actual packet as well */
+			actual_packet->flags |= FLAG_PARSE_ACE;
+		}
 		add_packet_dump(error, "actual", actual_packet, actual_usecs,
 				DUMP_SHORT);
 		packet_free(actual_packet);
@@ -1588,6 +1592,10 @@ static int do_outbound_script_packet(
 		socket->script.local_isn = ntohl(packet->tcp->seq);
 		DEBUGP("SYNACK script.local_isn: %u\n",
 		       socket->script.local_isn);
+	}
+	if (packet->flags & FLAG_PARSE_ACE) {
+		/* set numeric ACE count flag on actual packet as well */
+		live_packet->flags |= FLAG_PARSE_ACE;
 	}
 
 	DEBUGP("Expecting packet with payload %d bytes\n",

--- a/gtests/net/packetdrill/tcp_packet.c
+++ b/gtests/net/packetdrill/tcp_packet.c
@@ -82,7 +82,7 @@ static inline int tcp_flag_ace_count(const char *flags)
 
 	for (s = flags; *s != '\0'; ++s) {
 		if (strchr(ace_tcp_flags, *s))
-			return ((int)*s - (int)'0');
+			return (0x100 | ((int)*s - (int)'0'));
 	}
 	return 0;
 }


### PR DESCRIPTION
Output the ACE numeric values on error or verbose output, if the script was written using them.
Also make sure that a ACE numeric value of "0" set the FLAG_PARSE_ACE, even though no actual bits in the header are set.