### PR TITLE
packetdrill: support socket options TCP_FASTOPEN_KEY + NO_COOKIE

### DIFF
--- a/gtests/net/packetdrill/symbols_linux.c
+++ b/gtests/net/packetdrill/symbols_linux.c
@@ -187,6 +187,8 @@ struct int_symbol platform_symbols_table[] = {
 	{ TCP_USER_TIMEOUT,                 "TCP_USER_TIMEOUT"                },
 	{ TCP_FASTOPEN,                     "TCP_FASTOPEN"                    },
 	{ TCP_FASTOPEN_CONNECT,             "TCP_FASTOPEN_CONNECT"            },
+	{ TCP_FASTOPEN_KEY,                 "TCP_FASTOPEN_KEY"                },
+	{ TCP_FASTOPEN_NO_COOKIE,           "TCP_FASTOPEN_NO_COOKIE"          },
 	{ TCP_TIMESTAMP,                    "TCP_TIMESTAMP"                   },
 	{ TCP_NOTSENT_LOWAT,                "TCP_NOTSENT_LOWAT"               },
 	{ TCP_INQ,			    "TCP_INQ"			      },

--- a/gtests/net/packetdrill/tcp.h
+++ b/gtests/net/packetdrill/tcp.h
@@ -61,6 +61,8 @@
 #define TCP_SAVED_SYN            28  /* Get SYN headers recorded for connection */
 #define TCP_REPAIR_WINDOW        29  /* Get/set window parameters */
 #define TCP_FASTOPEN_CONNECT     30  /* Attempt FastOpen with connect */
+#define TCP_FASTOPEN_KEY         33  /* Set the key for Fast Open (cookie) */
+#define TCP_FASTOPEN_NO_COOKIE   34  /* Enable TFO without a TFO cookie */
 
 #ifndef TCP_INQ
 #define TCP_INQ			 36


### PR DESCRIPTION
These two sockets were missing:

  - `TCP_FASTOPEN_KEY`
  - `TCP_FASTOPEN_NO_COOKIE`

We just need to add the new symbols to support them.

They are being added to MPTCP in the kernel and validated with Packetdrill.

This commit was originally for the work-in-progress Packetdrill fork implementation supporting MPTCP but these options can be used for any "plain" TCP connections.