### PR TITLE
fix access to 'sock_extended_err' when generating cmsg from expressions

### DIFF
--- a/gtests/net/packetdrill/run_system_call.c
+++ b/gtests/net/packetdrill/run_system_call.c
@@ -199,6 +199,26 @@ static int check_type(const struct expression *expression,
 }
 
 /* Sets the value from the expression argument, checking that it is a
+ * valid s8 or u8, and matches the expected type. Returns STATUS_OK on
+ * success; on failure returns STATUS_ERR and sets error message.
+ */
+static int get_s8(struct expression *expression,
+		  s8 *value, char **error)
+{
+	if (check_type(expression, EXPR_INTEGER, error))
+		return STATUS_ERR;
+	if ((expression->value.num > UCHAR_MAX) ||
+	    (expression->value.num < CHAR_MIN)) {
+		asprintf(error,
+			 "Value out of range for 8-bit integer: %lld",
+			 expression->value.num);
+		return STATUS_ERR;
+	}
+	*value = expression->value.num;
+	return STATUS_OK;
+}
+
+/* Sets the value from the expression argument, checking that it is a
  * valid s32 or u32, and matches the expected type. Returns STATUS_OK on
  * success; on failure returns STATUS_ERR and sets error message.
  */
@@ -499,11 +519,11 @@ static int new_extended_err(const struct sock_extended_err_expr *expr,
 {
 	if (get_s32(expr->ee_errno, (s32 *)&ee->ee_errno, error))
 		return STATUS_ERR;
-	if (get_s32(expr->ee_origin, (s32 *)&ee->ee_origin, error))
+	if (get_s8(expr->ee_origin, (s8 *)&ee->ee_origin, error))
 		return STATUS_ERR;
-	if (get_s32(expr->ee_type, (s32 *)&ee->ee_type, error))
+	if (get_s8(expr->ee_type, (s8 *)&ee->ee_type, error))
 		return STATUS_ERR;
-	if (get_s32(expr->ee_code, (s32 *)&ee->ee_code, error))
+	if (get_s8(expr->ee_code, (s8 *)&ee->ee_code, error))
 		return STATUS_ERR;
 	if (get_s32(expr->ee_info, (s32 *)&ee->ee_info, error))
 		return STATUS_ERR;


### PR DESCRIPTION
when packetdrill builds a cmsg parsed from the script, it handles 'ee_origin', 'ee_type' and 'ee_code' as 32-bit numbers. These members of 'struct sock_extended_err' are 8-bit wide: because of this, TCP tests belonging to 'timestamping' and 'zerocopy' categories systematically fail on big endian architectures (such as s390x). For example, the value of 'ee_origin' is written in 'ee_pad':

 (gdb) set args -D TFO_COOKIE=de4f234f0f433a55 -D CMSG_LEVEL_IP=SOL_IP -D CMSG_TYPE_RECVERR=IP_RECVERR basic.pkt
 (gdb) r

[...]

 24: system call: recvmsg
 24: invoke call: recvmsg
 waiting until 1668090937472983 -- now is 1668090937472985
 expected: 0.000 actual: 0.000  (secs)

 Thread 1 "packetdrill" hit Breakpoint 2, new_extended_err (expr=0x111e7a0, ee=0x1124d80, error=0x3ffffff9730)
     at run_system_call.c:500
 500             if (get_s32(expr->ee_errno, (s32 *)&ee->ee_errno, error))
 (gdb) n
 502             if (get_s32(expr->ee_origin, (s32 *)&ee->ee_origin, error))
 (gdb) n
 504             if (get_s32(expr->ee_type, (s32 *)&ee->ee_type, error))
 (gdb) p *ee
 $46 = {ee_errno = 0, ee_origin = 0 '\000', ee_type = 0 '\000', ee_code = 0 '\000', ee_pad = 5 '\005', ee_info = 0,
  ee_data = 0}
 (gdb) up
 #1  0x000000000101d892 in cmsg_new (expr=0x111f740, msg=0x1124c60, error=0x3ffffff9730) at run_system_call.c:617
 617                             if (new_extended_err(ee_expr,
 (gdb) p *(struct sock_extended_err *)data
 $47 = {ee_errno = 0, ee_origin = 0 '\000', ee_type = 0 '\000', ee_code = 0 '\000', ee_pad = 5 '\005', ee_info = 0,
   ee_data = 0}
 (gdb)

fix it by providing a correct integer size for 'ee_origin', 'ee_type' and 'ee_code'.

Reported-by: Xiumei Mu <xmu@redhat.com>
Signed-off-by: Davide Caratti <dcaratti@redhat.com>