### PR TITLE
packetdrill: check accepted fd instead of listen fd

### DIFF
--- a/gtests/net/tcp/inq/server.pkt
+++ b/gtests/net/tcp/inq/server.pkt
@@ -46,5 +46,5 @@
 		    msg_control=[{cmsg_level=SOL_TCP,
 				  cmsg_type=TCP_CM_INQ,
 				  cmsg_data=1}]}, 0) = 10000
-// Now, receive error.
-   +0	read(3, ..., 2000) = -1 ENOTCONN (Transport endpoint is not connected)
+// Now, receive EOF.
+   +0	read(4, ..., 2000) = 0


### PR DESCRIPTION
It makes more sense to check the acceptd fd instead of listen fd in this test case.

Fixes #70.

Signed-off-by: Jianfeng Tan <henry.tjf@antgroup.com>