### PR TITLE
net-test: packetdrill: tcpdump: reduce sleep

### DIFF
--- a/gtests/net/packetdrill/in_netns.sh
+++ b/gtests/net/packetdrill/in_netns.sh
@@ -12,15 +12,27 @@ setup() {
 	ip netns add "${NETNS}"
 	ip -netns "${NETNS}" link set lo up
 	if [ -n "${TCPDUMP_OUTPUT}" ]; then
-		ip netns exec "${NETNS}" tcpdump -i any -s 150 -w "${TCPDUMP_OUTPUT}" &
+		mkdir -p "$(dirname "${TCPDUMP_OUTPUT}")"
+
+		ip netns exec "${NETNS}" tcpdump -i any -s 150 --immediate-mode --packet-buffered -w "${TCPDUMP_OUTPUT}" &
 		TCPDUMP_PID=$!
-		sleep 1 # give some time to TCPDump to start
+
+		# give some time to TCPDump to start
+		for _ in $(seq 10); do
+			[ -s "${TCPDUMP_OUTPUT}" ] && break
+			# BusyBox's sleep doesn't support float numbers, just wait 1 sec
+			if ! sleep 0.1 2>/dev/null; then
+				sleep 1
+				break
+			fi
+		done
 	fi
 }
 
 cleanup() {
 	if [ -n "${TCPDUMP_PID}" ]; then
-		sleep 1 # give some time to TCPDump to process the packets
+		# give some time to TCPDump to get the last packets
+		sleep 0.1 2>/dev/null || sleep 1
 		kill "${TCPDUMP_PID}"
 		wait "${TCPDUMP_PID}" 2>/dev/null || true
 	fi


### PR DESCRIPTION
As suggested by Davide, TCPDump's '--immediate-mode' will force the kernel to flush packets to userspace immediately after the reception. Thanks to that, the 'sleep 1' at the end of the test is no longer needed: the userspace will have all the packets when the kill signal will be received. Just to be on the safe side, we can keep a sleep 0.1, as recommended by Willem.

It looks like this TCPDump option is usually not recommended but because there should not be too many packets generated here with Packetdrill, it seems fine to have it and saves 1 second for each test. Note that it is not an exotic option as it is used by default when packets are not written in a file. Also, we now use '--packet-buffered' to reduce IO.

Now that the "immediate mode" is being used, it seems enough to just wait for the '.pcap' file to be created to know when TCPDump is ready.

While at it, the directory where the capture will be store is created if it didn't exist.