### PR TITLE
net-test: packetdrill: behaviour change for simult connect

### DIFF
--- a/gtests/net/tcp/fastopen/client/simultaneous-fast-open.pkt
+++ b/gtests/net/tcp/fastopen/client/simultaneous-fast-open.pkt
@@ -32,7 +32,6 @@
 
 // SYN data is never retried.
 +.045 < S. 1234:1234(0) ack 1001 win 14600 <mss 940,nop,nop,sackOK,nop,wscale 6,FO 12345678,nop,nop>
-   +0 > . 1001:1001(0) ack 1
 // The other end retries
   +.1 < P. 1:501(500) ack 1000 win 257
    +0 > . 1001:1001(0) ack 501


### PR DESCRIPTION
Since the kernel commit [23e89e8ee7be](https://git.kernel.org/pub/scm/linux/kernel/git/netdev/net-next.git/commit/?id=23e89e8ee7be) ("tcp: Don't drop SYN+ACK for simultaneous connect()."), the behaviour has changed for the simultaneous connect case: an unnecessary ACK is no longer sent.

We can then remove it from this packetdrill test checking this behaviour.

Note that this commit also breaks TFO in some cases -- e.g. when the `accept()` has been done before receiving data in the 3rd ACK, as done in the `fastopen/server/basic-cookie-not-reqd.pkt` test -- see this discussion on [lore](https://lore.kernel.org/netdev/20240710171246.87533-2-kuniyu@amazon.com/T/#u). A fix has been shared.