### PR TITLE
net-test: new behaviour change for simult TFO connect

### DIFF
--- a/gtests/net/tcp/fastopen/client/simultaneous-fast-open.pkt
+++ b/gtests/net/tcp/fastopen/client/simultaneous-fast-open.pkt
@@ -32,6 +32,7 @@
 
 // SYN data is never retried.
 +.045 < S. 1234:1234(0) ack 1001 win 14600 <mss 940,nop,nop,sackOK,nop,wscale 6,FO 12345678,nop,nop>
+   +0 > . 1001:1001(0) ack 1 <nop,nop,sack 0:1>
 // The other end retries
   +.1 < P. 1:501(500) ack 1000 win 257
    +0 > . 1001:1001(0) ack 501


### PR DESCRIPTION
A fix for the kernel commit [23e89e8ee7be](https://git.kernel.org/pub/scm/linux/kernel/git/netdev/net-next.git/commit/?id=23e89e8ee7be) ("tcp: Don't drop SYN+ACK for simultaneous connect().") has recently been shared on Netdev [1].

The ACK is back -- recently removed by commit 0312055 ("net-test: behaviour change for simultaneous TFO connect") -- but this time with the DSACK, as expected, see [1] and [2].

Link: https://lore.kernel.org/r/20240724-upstream-net-next-20240716-tcp-3rd-ack-consume-sk_socket-v3-1-d48339764ce9@kernel.org [1]
Link: https://lore.kernel.org/r/CADVnQy=Aky08HJGnozv-Nd97kRHBnxhw+caks+42FUyn+9GbPQ@mail.gmail.com [2]