### PR TITLE
net-test: packetdrill: fix the icmp echo bytes

### DIFF
--- a/gtests/net/packetdrill/icmp_packet.c
+++ b/gtests/net/packetdrill/icmp_packet.c
@@ -315,7 +315,7 @@ struct packet *new_icmp_packet(int address_family,
 	int ip_bytes = 0;
 
 	if (protocol == IPPROTO_TCP || protocol == IPPROTO_UDP) {
-		echoed_bytes = ip_fixed_bytes + ICMP_ECHO_BYTES;
+		echoed_bytes = ip_fixed_bytes + ICMP_ECHO_BYTES + payload_bytes;
 		icmp_bytes = icmp_header_len(address_family) + echoed_bytes;
 		ip_bytes = ip_header_bytes + icmp_bytes;
 	} else if (protocol == IPPROTO_RAW) {


### PR DESCRIPTION
When a icmp packet use opt_icmp_echoed option, the payload_bytes which provided by UDP, is not add
in icmp_bytes yet, this would make paylaod error when packet verify. For example:

in script the packet event like this:
	...
	+0 > icmp unreachable port_unreachable[udp(20)]
It will result in the following errors:
	live packet payload: expected 28 bytes vs actual 48 bytes

The packet_payload_len function is not contains the payload_bytes. Add the payload_bytes in echoed_bytes to fix this error.