### PR TITLE
Fix command injection and integer handling vulnerabilities in wire server

### DIFF
--- a/gtests/net/packetdrill/run_system_call.c
+++ b/gtests/net/packetdrill/run_system_call.c
@@ -2587,6 +2587,10 @@ static int syscall_getsockopt(struct state *state, struct syscall_spec *syscall,
 		return STATUS_ERR;
 
 	/* Allocate space for getsockopt output. */
+	if (script_optlen < 0) {
+		asprintf(error, "getsockopt: negative optlen %d", script_optlen);
+		return STATUS_ERR;
+	}
 	live_optlen = script_optlen;
 	live_optval = calloc(1, live_optlen + 1);
 	assert(live_optval != NULL);

--- a/gtests/net/packetdrill/run_system_call.c
+++ b/gtests/net/packetdrill/run_system_call.c
@@ -506,6 +506,10 @@ static int nla_expr_list_to_nla(struct expression_list *list,
 			die("out of bound u32 value specified\n");
 
 		get_nla_value(value, &val, num_bytes);
+		if ((char *)dst + NLA_ALIGN(NLA_HDRLEN + num_bytes) - (char *)start > dst_len) {
+			asprintf(error, "NLA buffer overflow: dst_len=%d exceeded", dst_len);
+			return STATUS_ERR;
+		}
 		dst += add_nla(dst, key_num, nla_info[key_num].length, &val);
 	}
 

--- a/gtests/net/packetdrill/wire_server_netdev.c
+++ b/gtests/net/packetdrill/wire_server_netdev.c
@@ -25,6 +25,7 @@
 
 #include "wire_server_netdev.h"
 
+#include <ctype.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/uio.h>
@@ -109,6 +110,17 @@ static void wire_server_netdev_dump_firewall_rules(const struct config *config)
 #endif
 }
 
+/* Validate that a string looks like an IP address (no shell metacharacters). */
+static bool is_safe_ip_string(const char *s)
+{
+	if (!s) return false;
+	for (; *s; ++s) {
+		if (!isalnum((unsigned char)*s) && *s != '.' && *s != ':' && *s != '%')
+			return false;
+	}
+	return true;
+}
+
 /* Drop incoming test traffic packets from the kernel under test, before they
  * are seen by the TCP/UDP/etc layers of the wire server machine. In some cases
  * (e.g., if a network does not allow spoofing) the packetdrill test traffic
@@ -122,6 +134,9 @@ static void wire_server_netdev_drop_test_traffic(const struct config *config)
 {
 #ifdef linux
 	char *command = NULL;
+
+	if (!is_safe_ip_string(config->live_local_ip_string))
+		die("wire_server_netdev: unsafe IP address string\n");
 
 	asprintf(&command,
 		 "("
@@ -155,6 +170,9 @@ static void wire_server_netdev_permit_test_traffic(const struct config *config)
 {
 #ifdef linux
 	char *command = NULL;
+
+	if (!is_safe_ip_string(config->live_local_ip_string))
+		die("wire_server_netdev: unsafe IP address string\n");
 
 	asprintf(&command,
 		 "("


### PR DESCRIPTION
## Security fixes

**1. Command injection via live_local_ip_string** (`wire_server_netdev.c`)
`config->live_local_ip_string` is formatted directly into a shell command passed to `system()` without sanitization. A specially crafted IP string containing shell metacharacters would allow command injection. Fixed by adding IP address validation before building the command.

**2. Missing bounds check in nla_expr_list_to_nla** (`run_system_call.c`)
The `dst_len` parameter is accepted but not enforced in the loop body, allowing writes past the end of the destination buffer. Added bounds check before each write.

**3. Negative optlen causes huge allocation in getsockopt** (`run_system_call.c`)
A negative `script_optlen` is silently cast to `socklen_t` (unsigned 32-bit), causing `calloc` to request ~4GB of memory. Added a non-negative check before the cast.