### PR TITLE
fix: use subprocess instead of os.system in set_sysctls.py

### DIFF
--- a/gtests/net/tcp/common/set_sysctls.py
+++ b/gtests/net/tcp/common/set_sysctls.py
@@ -17,7 +17,7 @@ at the end.
 __author__ = ('brakmo@google.com (Lawrence Brakmo)')
 
 import os
-import subprocess
+import stat
 import sys
 
 filename = '/tmp/sysctl_restore_%s.sh' % os.environ['PACKETDRILL_PID']
@@ -31,11 +31,12 @@ for a in sys.argv[1:]:
   # sysctl[0] contains the proc-file name, sysctl[1] the new value
 
   # read current value and add restore command to file
-  cur_val = subprocess.check_output(['cat', sysctl[0]], universal_newlines=True)
+  with open(sysctl[0], 'r') as f:
+    cur_val = f.read()
   print('echo "%s" > %s' % (cur_val.strip(), sysctl[0]), file=restore_file)
 
   # set new value
-  cmd = 'echo "%s" > %s' % (sysctl[1], sysctl[0])
-  os.system(cmd)
+  with open(sysctl[0], 'w') as f:
+    f.write(sysctl[1] + '\n')
 
-os.system('chmod u+x %s' % filename)
+os.chmod(filename, os.stat(filename).st_mode | stat.S_IXUSR)


### PR DESCRIPTION
## Summary
Fix critical severity security issue in `gtests/net/tcp/common/set_sysctls.py`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | CRITICAL |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `gtests/net/tcp/common/set_sysctls.py:29` |
| **CWE** | CWE-78 |

**Description**: The script reads sysctl path/value pairs directly from sys.argv[1:] at line 29 and constructs shell command strings using % string formatting. These strings are passed directly to os.system() at line 39 (for writing sysctl values) and line 41 (for chmod). No sanitization, validation, or allowlisting of input is performed. An attacker who controls the command-line arguments — including any CI/CD pipeline, test orchestration system, or local user invoking the script — can inject shell metacharacters to execute arbitrary OS commands. Because sysctl manipulation requires root privileges, this script is routinely executed as root, making successful exploitation equivalent to full system compromise.

## Changes
- `gtests/net/tcp/common/set_sysctls.py`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
